### PR TITLE
Fix installation on non-ARM Linux

### DIFF
--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -16,7 +16,7 @@ elif [ "$(uname)" = "Linux" ]; then
     if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
         url="https://github.com/C123R/helm-blob/releases/download/v${version}/helm-blob_linux_arm64_v${version}.tar.gz"
     else
-        url="https://github.com/C123R/helm-blob/releases/download/v${version}/helm-blob__linux_amd64_v${version}.tar.gz"
+        url="https://github.com/C123R/helm-blob/releases/download/v${version}/helm-blob_linux_amd64_v${version}.tar.gz"
     fi
 else
     url="https://github.com/C123R/helm-blob/releases/download/v${version}/helm-blob_windows_amd64_v${version}.tar.gz"


### PR DESCRIPTION
The installation on Linux fails due to a double dash, probably a typo.